### PR TITLE
Setup timer 4 to use frequency and phase correct dual slope PWM

### DIFF
--- a/src/ATMlib.cpp
+++ b/src/ATMlib.cpp
@@ -7,7 +7,6 @@ byte tickRate;
 const word *trackList;
 const byte *trackBase;
 uint8_t pcm __attribute__((used)) = 128;
-bool half __attribute__((used));
 
 byte ChannelActiveMute = 0b11110000;
 //                         ||||||||
@@ -119,11 +118,12 @@ void ATMsynth::play(const byte *song) {
   osc[3].freq = 0x0001; // Seed LFSR
   channel[3].freq = 0x0001; // xFX
 
-  TCCR4A = 0b01000010;    // Fast-PWM 8-bit
-  TCCR4B = 0b00000001;    // 62500Hz
+  TCCR4A = 0b01000010;    // Set both OC4A and #OC4A pins
+  TCCR4B = 0b10000010;    // Frequency correct PWM (dual slope), clk/2/OCR4C ~= 31250Hz
   OCR4C  = 0xFF;          // Resolution to 8-bit (TOP=0xFF)
   OCR4A  = 0x80;
-  TIMSK4 = 0b00000100;
+  TIMSK4 = 0b00000100;    // Enable overflow interrupt
+  TCCR4D = 0b00000001;    // Phase correct PWM (dual slope)
 
 
   // Load a melody stream and start grinding samples

--- a/src/ATMlib.h
+++ b/src/ATMlib.h
@@ -14,8 +14,6 @@ extern const word *trackList;
 extern const byte *trackBase;
 extern uint8_t pcm;
 
-extern bool half;
-
 class ATMsynth {
 
   public:
@@ -63,15 +61,6 @@ ISR(TIMER4_OVF_vect, ISR_NAKED) { \
                 "push r2                                          " "\n\t" \
                 "in   r2,                    __SREG__             " "\n\t" \
                 "push r18                                         " "\n\t" \
-                "lds  r18, half \n\t" \
-                "com  r18 \n\t" \
-                "sts  half, r18 \n\t" \
-                "breq continue \n\t" \
-                "pop  r18                                         " "\n\t" \
-                "out  __SREG__,              r2                   " "\n\t" \
-                "pop  r2                                          " "\n\t" \
-                "reti                                             " "\n\t" \
-                "continue: \n\t" \
                 "push r27                                         " "\n\t" \
                 "push r26                                         " "\n\t" \
                 "push r0                                          " "\n\t" \


### PR DESCRIPTION
This halves the rate of interrupts being serviced.

I tested most of ATMlib examples and it sounds the same to me. I haven't hooked up a scope and compared waveforms because I only have access to one Arduboy right now and I'd rather not disassemble it.