### PR TITLE
Fix warnings

### DIFF
--- a/src/ATMlib.cpp
+++ b/src/ATMlib.cpp
@@ -212,8 +212,10 @@ void ATM_playroutine() {
         vf += (ch->volFreSlide);
         if (!(ch->volFreConfig & 0x80)) {
           if (vf < 0) vf = 0;
-          else if (ch->volFreConfig & 0x40) if (vf > 9397) vf = 9397;
-            else if (!(ch->volFreConfig & 0x40)) if (vf > 63) vf = 63;
+          else if (ch->volFreConfig & 0x40) {
+            if (vf > 9397) vf = 9397;
+          }
+          else if (vf > 63) vf = 63;
         }
         (ch->volFreConfig & 0x40) ? ch->freq = vf : ch->vol = vf;
       }
@@ -244,8 +246,10 @@ void ATM_playroutine() {
       int16_t vt = ((ch->treviConfig & 0x40) ? ch->freq : ch->vol);
       vt = (ch->treviCount & 0x80) ? (vt + ch->treviDepth) : (vt - ch->treviDepth);
       if (vt < 0) vt = 0;
-      else if (ch->treviConfig & 0x40) if (vt > 9397) vt = 9397;
-        else if (!(ch->treviConfig & 0x40)) if (vt > 63) vt = 63;
+      else if (ch->treviConfig & 0x40) {
+        if (vt > 9397) vt = 9397;
+      }
+      else if (vt > 63) vt = 63;
       (ch->treviConfig & 0x40) ? ch->freq = vt : ch->vol = vt;
       if ((ch->treviCount & 0x1F) < (ch->treviConfig & 0x1F)) ch->treviCount++;
       else {

--- a/src/ATMlib.cpp
+++ b/src/ATMlib.cpp
@@ -162,10 +162,12 @@ void ATMsynth::playPause() {
 // Toggle mute on/off on a channel, so it can be used for sound effects
 // So you have to call it before and after the sound effect
 void ATMsynth::muteChannel(byte ch) {
+  static_cast<void>(ch);
   ChannelActiveMute += (1 << 0 );
 }
 
 void ATMsynth::unMuteChannel(byte ch) {
+  static_cast<void>(ch);
   ChannelActiveMute &= (~(1 << 0 ));
 }
 

--- a/src/ATMlib.cpp
+++ b/src/ATMlib.cpp
@@ -267,7 +267,8 @@ void ATM_playroutine() {
         byte cmd = pgm_read_byte(ch->ptr++);
         if (cmd < 64) {
           // 0 … 63 : NOTE ON/OFF
-          if (ch->note = cmd) ch->note += ch->transConfig;
+          ch->note = cmd;
+          if(cmd != 0) ch->note += ch->transConfig;
           ch->freq = pgm_read_word(&noteTable[ch->note]);
           if (!ch->volFreConfig) ch->vol = ch->reCount;
           if (ch->arpTiming & 0x20) ch->arpCount = 0; // ARP retriggering


### PR DESCRIPTION
Fixes all the outstanding warnings.

The fix for the 'ambiguous else' warning also fixes a bug.
Previously this:
```cpp
else if (ch->volFreConfig & 0x40) if (vf > 9397) vf = 9397;
else if (!(ch->volFreConfig & 0x40)) if (vf > 63) vf = 63;
```
Was being interpreted by the compiler as this:
```cpp
else if (ch->volFreConfig & 0x40)
{
	if (vf > 9397)
	{
		vf = 9397;
	}
	else if (!(ch->volFreConfig & 0x40))
	{
		if (vf > 63)
		{
			vf = 63;
		}
	}
}
```
And now it's being interpreted correctly as:
```cpp
else if (ch->volFreConfig & 0x40)
{
	if (vf > 9397)
	{
		vf = 9397;
	}
}
else // if (!(ch->volFreConfig & 0x40))
{
	if (vf > 63)
	{
		vf = 63;
	}
}
```
(Obviously there's a small code size increase as a result of this fix.)